### PR TITLE
Use `nav_panel()`s and `ui.popover()` to group UI and outputs

### DIFF
--- a/basics/app.py
+++ b/basics/app.py
@@ -9,7 +9,9 @@ import altair as alt
 from shiny import reactive
 from shiny.express import render, ui, input
 
-from shinywidgets import render_plotly, render_widget, render_altair
+from faicons import icon_svg
+
+from shinywidgets import render_plotly, render_altair
 import plotly.express as px
 
 import folium
@@ -17,7 +19,7 @@ from folium.plugins import HeatMap
 
 import seaborn as sns
 
-ui.page_opts(class_="py-3")
+ui.page_opts(title="Sales Dashboard", fillable=True)
 
 
 def apply_common_styles(fig):
@@ -38,203 +40,77 @@ def dat():
     return pd.read_csv(infile)
 
 
-with ui.card(full_screen=True):
-    ui.card_header("Sales by City in 2023")
-    with ui.layout_sidebar():
-        with ui.sidebar(open="open", bg="#f8f8f8"):
-            ui.input_select(
-                "select",
-                "Select an option below:",
-                [
-                    "Dallas (TX)",
-                    "Boston (MA)",
-                    "Los Angeles (CA)",
-                    "San Francisco (CA)",
-                    "Seattle (WA)",
-                    "Atlanta (GA)",
-                    "New York City (NY)",
-                    "Portland (OR)",
-                    "Austin (TX)",
-                    "Portland (ME)",
-                ],
-            )
+# Push nav links to the right
+ui.nav_spacer()
 
-        @render_altair
-        def sales_over_time():
-            df = dat()
-            df["date"] = pd.to_datetime(df["order_date"])
-            df["month"] = df["date"].dt.month_name()
-            # Define the order of the months to ensure they appear chronologically
-            month_order = [
-                "January",
-                "February",
-                "March",
-                "April",
-                "May",
-                "June",
-                "July",
-                "August",
-                "September",
-                "October",
-                "November",
-                "December",
-            ]
-
-            # Creating a month order for sorting in Altair
-            df["month"] = pd.Categorical(
-                df["month"], categories=month_order, ordered=True
-            )
-            counts = (
-                df.groupby(["month", "city"], observed=True)["quantity_ordered"]
-                .sum()
-                .reset_index()
-            )
-            city_counts = counts[counts["city"] == input.select()]
-            # Create the Altair chart
-            chart = (
-                alt.Chart(city_counts)
-                .mark_bar()
-                .encode(
-                    x="month",
-                    y="quantity_ordered",
-                    tooltip=["city", "month", "quantity_ordered"],
+with ui.nav_panel("Sales by City"):
+    with ui.card(full_screen=True):
+        with ui.layout_sidebar():
+            with ui.sidebar(open="open", bg="#f8f8f8"):
+                ui.input_select(
+                    "select",
+                    "Select an option below:",
+                    [
+                        "Dallas (TX)",
+                        "Boston (MA)",
+                        "Los Angeles (CA)",
+                        "San Francisco (CA)",
+                        "Seattle (WA)",
+                        "Atlanta (GA)",
+                        "New York City (NY)",
+                        "Portland (OR)",
+                        "Austin (TX)",
+                        "Portland (ME)",
+                    ],
                 )
-                .properties(title=f"Sales Over Time in {input.select()}")
-                .configure_axis(labelAngle=0)  # Adjust label angle if needed
-            )
-            return chart
 
-
-with ui.layout_columns(widths=1 / 2):
-    with ui.navset_card_underline():
-        with ui.nav_panel("Top Sellers"):
-            ui.input_numeric(
-                "items", "Number of Items", 5, min=1, max=10, step=None, width=0.5
-            )
-
-            @render_plotly
-            def top_sellers():
+            @render_altair
+            def sales_over_time():
                 df = dat()
-                top_5_products = (
-                    df.groupby("product")["quantity_ordered"]
+                df["date"] = pd.to_datetime(df["order_date"])
+                df["month"] = df["date"].dt.month_name()
+                # Define the order of the months to ensure they appear chronologically
+                month_order = [
+                    "January",
+                    "February",
+                    "March",
+                    "April",
+                    "May",
+                    "June",
+                    "July",
+                    "August",
+                    "September",
+                    "October",
+                    "November",
+                    "December",
+                ]
+
+                # Creating a month order for sorting in Altair
+                df["month"] = pd.Categorical(
+                    df["month"], categories=month_order, ordered=True
+                )
+                counts = (
+                    df.groupby(["month", "city"], observed=True)["quantity_ordered"]
                     .sum()
-                    .nlargest(input.items())
                     .reset_index()
                 )
-
-                fig = px.bar(top_5_products, x="product", y="quantity_ordered")
-
-                fig.update_traces(
-                    marker_color=top_5_products["quantity_ordered"],
-                    marker_colorscale="Blues",
+                city_counts = counts[counts["city"] == input.select()]
+                # Create the Altair chart
+                chart = (
+                    alt.Chart(city_counts)
+                    .mark_bar()
+                    .encode(
+                        x="month",
+                        y="quantity_ordered",
+                        tooltip=["city", "month", "quantity_ordered"],
+                    )
+                    .properties(title=f"Sales Over Time in {input.select()}")
+                    .configure_axis(labelAngle=0)  # Adjust label angle if needed
                 )
-                apply_common_styles(fig)
-                return fig
+                return chart
 
-        with ui.nav_panel("Top Sellers Value ($)"):
-
-            @render_plotly
-            def top_sellers_value():
-                df = dat()
-                df["value"] = df["quantity_ordered"] * df["price_each"]
-                top_5_products = (
-                    df.groupby("product")["value"]
-                    .sum()
-                    .nlargest(input.items())
-                    .reset_index()
-                )
-
-                fig = px.bar(top_5_products, x="product", y="value")
-
-                fig.update_traces(
-                    marker_color=top_5_products["value"], marker_colorscale="Blues"
-                )
-                apply_common_styles(fig)
-                return fig
-
-        with ui.nav_panel("Lowest Sellers"):
-
-            @render_plotly
-            def lowest_sellers():
-                df = dat()
-                top_5_products = (
-                    df.groupby("product")["quantity_ordered"]
-                    .sum()
-                    .nsmallest(input.items())
-                    .reset_index()
-                    .sort_values("quantity_ordered", ascending=False)
-                )
-
-                fig = px.bar(top_5_products, x="product", y="quantity_ordered")
-
-                fig.update_traces(
-                    marker_color=top_5_products["quantity_ordered"],
-                    marker_colorscale="Reds",
-                )
-                apply_common_styles(fig)
-                return fig
-
-        with ui.nav_panel("Lowest Sellers Value ($)"):
-
-            @render_plotly
-            def lowest_sellers_value():
-                df = dat()
-                df["value"] = df["quantity_ordered"] * df["price_each"]
-                top_5_products = (
-                    df.groupby("product")["value"]
-                    .sum()
-                    .nsmallest(input.items())
-                    .reset_index()
-                    .sort_values("value", ascending=False)
-                )
-
-                fig = px.bar(top_5_products, x="product", y="value")
-
-                fig.update_traces(
-                    marker_color=top_5_products["value"], marker_colorscale="Reds"
-                )
-                apply_common_styles(fig)
-                return fig
-
-    with ui.card():
-
-        @render.plot
-        def time_heatmap():
-            # Step 1: Extract the hour from the order_date
-            df = dat()
-            df["order_date"] = pd.to_datetime(df["order_date"])
-            df["hour"] = df["order_date"].dt.hour
-
-            # Step 2: Aggregate data by hour
-            hourly_counts = df["hour"].value_counts().sort_index()
-
-            # Step 3: Prepare data for heatmap (optional: create a dummy dimension if needed)
-            # For simplicity, let's assume you want to view by hours (24 hrs) and just map counts directly.
-            heatmap_data = np.zeros((24, 1))  # 24 hours, 1 dummy column
-            for hour in hourly_counts.index:
-                heatmap_data[hour, 0] = hourly_counts[hour]
-
-            # Convert heatmap data to integer if needed
-            heatmap_data = heatmap_data.astype(int)
-
-            # Step 4: Plot with Seaborn
-            plt.figure(figsize=(10, 8))
-            sns.heatmap(
-                heatmap_data,
-                annot=True,
-                fmt="d",
-                cmap="coolwarm",
-                cbar=False,
-                xticklabels=[],
-                yticklabels=[f"{i}:00" for i in range(24)],
-            )
-            plt.title("Number of Orders by Hour of Day")
-            plt.ylabel("Hour of Day")
-            plt.xlabel("Order Count")
-
-
-with ui.navset_card_underline():
-    with ui.nav_panel("Sales Locations"):
+    with ui.card(full_screen=True):
+        ui.card_header("Sales Locations")
 
         @render.ui
         def heatmap():
@@ -253,9 +129,143 @@ with ui.navset_card_underline():
             return map
 
 
-with ui.navset_card_underline():
-    with ui.nav_panel("Dataframe Sample"):
+with ui.nav_panel("Top Sellers"):
+    with ui.layout_columns(col_widths=(8, 4)):
+        with ui.navset_card_underline():
+            with ui.nav_panel("Top Sellers"):
 
-        @render.data_frame
-        def frame():
-            return dat().head(1000)
+                @render_plotly
+                def top_sellers():
+                    df = dat()
+                    df["value"] = (
+                        df["quantity_ordered"]
+                        if input.sellers_value() == "quantity"
+                        else df["quantity_ordered"] * df["price_each"]
+                    )
+
+                    top_n_products = (
+                        df.groupby("product")["value"]
+                        .sum()
+                        .nlargest(input.items())
+                        .reset_index()
+                    )
+
+                    fig = px.bar(top_n_products, x="product", y="value")
+
+                    fig.update_traces(
+                        marker_color=top_n_products["value"],
+                        marker_colorscale="Blues",
+                    )
+                    fig.update_layout(
+                        xaxis_title=None,
+                        yaxis_title=(
+                            "Quantity ordered"
+                            if input.sellers_value() == "quantity"
+                            else "Total order value ($)"
+                        ),
+                    )
+                    apply_common_styles(fig)
+                    return fig
+
+            with ui.nav_panel("Lowest Sellers"):
+
+                @render_plotly
+                def lowest_sellers():
+                    df = dat()
+                    df["value"] = (
+                        df["quantity_ordered"]
+                        if input.sellers_value() == "quantity"
+                        else df["quantity_ordered"] * df["price_each"]
+                    )
+
+                    top_n_products = (
+                        df.groupby("product")["value"]
+                        .sum()
+                        .nsmallest(input.items())
+                        .reset_index()
+                    )
+
+                    fig = px.bar(top_n_products, x="product", y="value")
+
+                    fig.update_traces(
+                        marker_color=top_n_products["value"],
+                        marker_colorscale="Blues",
+                    )
+                    fig.update_layout(
+                        xaxis_title=None,
+                        yaxis_title=(
+                            "Quantity ordered"
+                            if input.sellers_value() == "quantity"
+                            else "Total order value ($)"
+                        ),
+                    )
+                    apply_common_styles(fig)
+                    return fig
+
+            ui.nav_spacer()
+
+            with ui.nav_control():
+                with ui.popover():
+                    icon_svg("gear", a11y="sem", title="Settings")
+                    ui.input_radio_buttons(
+                        "sellers_value",
+                        "Top sellers by",
+                        inline=True,
+                        choices={
+                            "quantity": "Quantity",
+                            "value": "Value ($)",
+                        },
+                    )
+                    ui.input_slider(
+                        "items",
+                        "Number of Items",
+                        value=5,
+                        min=1,
+                        max=10,
+                        step=1,
+                        width=0.5,
+                    )
+
+        with ui.card():
+            ui.card_header("Number of Orders by Hour of Day")
+
+            @render.plot
+            def time_heatmap():
+                # Step 1: Extract the hour from the order_date
+                df = dat()
+                df["order_date"] = pd.to_datetime(df["order_date"])
+                df["hour"] = df["order_date"].dt.hour
+
+                # Step 2: Aggregate data by hour
+                hourly_counts = df["hour"].value_counts().sort_index()
+
+                # Step 3: Prepare data for heatmap (optional: create a dummy dimension if needed)
+                # For simplicity, let's assume you want to view by hours (24 hrs) and just map counts directly.
+                heatmap_data = np.zeros((24, 1))  # 24 hours, 1 dummy column
+                for hour in hourly_counts.index:
+                    heatmap_data[hour, 0] = hourly_counts[hour]
+
+                # Convert heatmap data to integer if needed
+                heatmap_data = heatmap_data.astype(int)
+
+                # Step 4: Plot with Seaborn
+                plt.figure(figsize=(10, 8))
+                sns.heatmap(
+                    heatmap_data,
+                    annot=True,
+                    fmt="d",
+                    cmap="coolwarm",
+                    cbar=False,
+                    xticklabels=[],
+                    yticklabels=[f"{i}:00" for i in range(24)],
+                )
+                plt.ylabel("Hour of Day")
+                plt.xlabel("Order Count")
+
+
+with ui.nav_panel("Data"):
+    ui.h3("Sales Data Sample")
+
+    @render.data_frame
+    def frame():
+        return dat().head(1000)

--- a/basics/requirements.txt
+++ b/basics/requirements.txt
@@ -1,7 +1,10 @@
 pandas
 plotly
+faicons
 folium
 matplotlib
+numpy
+pytz
 shiny
 shinywidgets
 seaborn


### PR DESCRIPTION
Awesome app! 

I made a few small changes to take the app one step further. By the way, in my experience, this is a natural step in the process. Most of my apps look exactly like the one you've created with almost everything on the same page. It's a great way to see what you're working on, but it's not the best experience as an app user.

In the updated app, I used `ui.nav_panel()` to organize the app into three pages:

1. Sales by city
    * Sales by city bar plot plot
    * Sales by location map
3. Top sellers
    * Top/lowest sellers plot card
    * Sales by hour of day
5. Data
    * Data sample table

Here's a quick screen recording walking through the app

https://github.com/KeithGalli/posit/assets/5420529/b80df3b2-f775-47de-be32-24d64a4901ea

Another change I made was in the top/lowest sellers plot card. Currently, there's an input in the first tab of this card that affects all of the card's tabs. I consolidated the reactive logic into two tabs -- top sellers and lowest sellers -- and then I used `ui.popover()` and the `faicons` package to add a settings button to the card. In the settings button, users can pick between top/lowest sellers by quantity or total value and can also choose the number of top items to show in the plot.

One last small change I made in a few places was to replace `ui.navset_card_tabs()` where the card had a single table with `ui.card()` and `ui.card_header()`. The second function gives the card a title and is generally a little friendlier when there's only one thing shown in the card.

Oh, and I also added a few missing packages to `basic/requirements.txt`.

Let me know if you have any questions!